### PR TITLE
Update birdbot.py

### DIFF
--- a/birdbot.py
+++ b/birdbot.py
@@ -96,8 +96,8 @@ async def countdown():
              voiceclient.channel = None
              caller = None
              vplayer.stop()
-             countdownbool = False
         await asyncio.sleep(1)
+    countdownbool = False
     return
 
 @client.event


### PR DESCRIPTION
Moved the global variable change countdownbool = False to outside the countdown timer. What I think was happening was if it would disconnect once it would reset, but if it was interrupted during its loop it would cancel without resetting the timer bool.